### PR TITLE
Fix two column layout for videos

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,7 @@ section {
 }
 .video-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
     gap: 20px;
     margin-top: 20px;
 }


### PR DESCRIPTION
## Summary
- tweak CSS so video blocks render in exactly two columns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687165463f108323b94640eccd08b487